### PR TITLE
Update jvmtop.sh for the openjdk issue.

### DIFF
--- a/src/main/wrappers/jvmtop.sh
+++ b/src/main/wrappers/jvmtop.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
-# jvmtop - java monitoring for the command-line 
+# jvmtop - java monitoring for the command-line
 # launch script
 #
 # author: Markus Kolb
-# 
+# modified by Charan Ramireddy
+
 DIR=$( cd $(dirname $0) ; pwd -P )
 
 if [ -z "$JAVA_HOME" ] ; then
@@ -14,8 +15,12 @@ fi
 TOOLSJAR="$JAVA_HOME/lib/tools.jar"
 
 if [ ! -f "$TOOLSJAR" ] ; then
+   if [ ! -f "$JAVA_HOME/../lib/tools.jar" ] ; then
         echo "$JAVA_HOME seems to be no JDK!" >&2
         exit 1
+   else
+       TOOLSJAR="$JAVA_HOME/../lib/tools.jar"
+   fi
 fi
 
 "$JAVA_HOME"/bin/java $JAVA_OPTS -cp "$DIR/jvmtop.jar:$TOOLSJAR" \


### PR DESCRIPTION
This will allow jvmtop.sh to look for tools.jar if openJDK is the default JDK.